### PR TITLE
fix(ci): make deploy workflows self-bootstrapping

### DIFF
--- a/.github/workflows/deploy-pg-protocol.yml
+++ b/.github/workflows/deploy-pg-protocol.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'packages/pg-protocol/**'
+      - '.github/workflows/deploy-pg-protocol.yml'
   workflow_dispatch:
     inputs:
       version:
@@ -20,6 +21,16 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # IMPORTANT: install/build/publish strictly inside packages/pg-protocol/
+    # to avoid touching the workspace root. The root yarn.lock contains the
+    # `pg-protocol: npm:@supabase/pg-protocol@^X.Y.Z` alias, which would fail
+    # resolution any time we bump pg-protocol's version (the new version is
+    # not on npm yet — that's exactly what this workflow is publishing).
+    # pg-protocol has no runtime deps and only TS toolchain devDeps, so
+    # `npm install` inside the package directory is fully self-contained.
+    defaults:
+      run:
+        working-directory: packages/pg-protocol
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -29,15 +40,19 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Install pg-protocol devDependencies (isolated, no workspace root)
+        # --workspaces=false + --prefix . is required to stop npm from
+        # walking up to the workspace root package.json. Without it, npm
+        # tries to resolve every workspace package's deps and trips on
+        # the unpublished `@supabase/pg-protocol@^X.Y.Z` alias in pg.
+        run: npm install --no-package-lock --no-audit --no-fund --workspaces=false --prefix .
 
       - name: Build package
-        run: cd packages/pg-protocol && yarn build
+        run: npm run build
 
       # Ensure npm 11.5.1 or later is installed for trusted publishing support
       - name: Update npm
         run: npm install -g npm@latest
 
       - name: Publish to npm
-        run: cd packages/pg-protocol && npm publish
+        run: npm publish

--- a/.github/workflows/deploy-pg.yml
+++ b/.github/workflows/deploy-pg.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'packages/pg/**'
+      - '.github/workflows/deploy-pg.yml'
   workflow_dispatch:
     inputs:
       version:
@@ -20,6 +21,17 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # IMPORTANT: do NOT run a workspace-root install here. pg's
+    # package.json declares `pg-protocol: npm:@supabase/pg-protocol@^X.Y.Z`,
+    # and any time we bump pg-protocol's version this workflow would fire
+    # before that version is on npm (deploy-pg-protocol.yml runs in
+    # parallel on the same merge commit). Workspace install would then
+    # fail at resolution. pg is plain JavaScript (no build step, no TS
+    # compile), so `npm publish` can pack the source files listed under
+    # the `files` field directly without resolving any dependencies.
+    defaults:
+      run:
+        working-directory: packages/pg
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -29,12 +41,9 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
       # Ensure npm 11.5.1 or later is installed for trusted publishing support
       - name: Update npm
         run: npm install -g npm@latest
 
       - name: Publish to npm
-        run: cd packages/pg && npm publish
+        run: npm publish


### PR DESCRIPTION
## Context

After merging #29, both `deploy-pg.yml` and `deploy-pg-protocol.yml` failed at the `Install dependencies` step:

```
error Couldn't find any versions for "@supabase/pg-protocol" that matches "^1.13.0"
```

- [Failed pg-protocol deploy run](https://github.com/supabase/node-postgres/actions/runs/25722788243/job/75527851307)
- [Failed pg deploy run](https://github.com/supabase/node-postgres/actions/runs/25722788282/job/75527851185)

## Root cause (chicken-and-egg)

Both workflows ran `yarn install --frozen-lockfile` from the **workspace root**. That triggers resolution for *every* workspace package — including the `pg-protocol: npm:@supabase/pg-protocol@^1.13.0` alias declared in `packages/pg/package.json`. The latest published `@supabase/pg-protocol` was `1.8.0`, so resolution failed before either workflow could publish anything. The two workflows ran in parallel on the same merge commit and both died at install.

This will recur on **every future bump** of `pg-protocol` if not fixed at the workflow level.

## Fix: scope each workflow to its own package

### `deploy-pg-protocol.yml`
`pg-protocol` is a leaf TypeScript package — no runtime deps, only TS toolchain devDeps. Install + build + publish runs inside `packages/pg-protocol/` only. Uses `npm install --workspaces=false --prefix .` so `npm` does not walk up to the workspace root `package.json` (verified locally: without the flags, npm pulls in the root devDeps and hits an `@typescript-eslint/eslint-plugin` peer conflict).

### `deploy-pg.yml`
`pg` is plain JavaScript — no build step (`esm/index.mjs` is hand-written). `npm publish` packs from the `files` field without resolving any dependencies. Drop the install step entirely and just `cd packages/pg && npm publish`.

Also extended each workflow's `paths` trigger to include the workflow file itself, so future tweaks are testable without an unrelated source change.

## Test plan

Verified locally (`packages/pg-protocol`): `npm install --workspaces=false --prefix . && npm run build` produces `dist/`, and `npm publish --dry-run` lists the expected 42 files / 36.1 kB tarball.

Verified locally (`packages/pg`): `npm publish --dry-run` (no install) lists the expected 21 files / 25.6 kB tarball.

After merge: trigger both workflows manually via `workflow_dispatch` to publish the still-pending `@supabase/pg-protocol@1.13.0` and `@supabase/pg@8.20.0` from the previous merge.