### PR TITLE
chore: sync upstream/master + bump @supabase/pg to 8.21.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
       PGTESTNOSSL: 'true'
       SCRAM_TEST_PGUSER: scram_test
       SCRAM_TEST_PGPASSWORD: test4scram
+      SCRAM_TEST_PGUSER_UNICODE: scram_unicode_test
+      # Raw form of a password whose NFKC normalization differs from itself.
+      # U+2168 (ROMAN NUMERAL IX) decomposes to ASCII "IX" under NFKC; the
+      # server stores the verifier from the SASLprep-normalized form, so the
+      # client must apply SASLprep too. This is the regression check for the
+      # RFC 4013 fix in packages/pg/lib/crypto/sasl.js.
+      SCRAM_TEST_PGPASSWORD_UNICODE: "IX-\u2168"
     steps:
       - name: Show OS
         run: |
@@ -63,7 +70,8 @@ jobs:
       - run: |
           psql \
             -c "SET password_encryption = 'scram-sha-256'" \
-            -c "CREATE ROLE scram_test LOGIN PASSWORD 'test4scram'"
+            -c "CREATE ROLE scram_test LOGIN PASSWORD 'test4scram'" \
+            -c "CREATE ROLE scram_unicode_test LOGIN PASSWORD U&'IX-\2168'"
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/packages/pg-native/package.json
+++ b/packages/pg-native/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/brianc/node-postgres/tree/master/packages/pg-native",
   "dependencies": {
-    "libpq": "^1.11.0",
+    "libpq": "^1.8.15",
     "pg-types": "2.2.0"
   },
   "devDependencies": {

--- a/packages/pg/lib/crypto/sasl.js
+++ b/packages/pg/lib/crypto/sasl.js
@@ -2,6 +2,34 @@
 const crypto = require('./utils')
 const { signatureAlgorithmHashFromCertificate } = require('./cert-signatures')
 
+// SASLprep (RFC 4013) — minimal in-tree implementation.
+//
+// Per RFC 5802 §2.2, the SCRAM-SHA-256 client must normalize the password via
+// SASLprep before feeding it into PBKDF2. PostgreSQL's server applies the same
+// SASLprep when computing the stored verifier, and libpq does the same client
+// side, so passwords whose NFKC form differs from the raw form
+// would otherwise authenticate against psql/libpq but fail against pg with `28P01`.
+//
+// We deliberately implement only the three steps that change the byte content:
+//   1. RFC 3454 Table C.1.2 (non-ASCII space) → U+0020 SPACE.
+//   2. RFC 3454 Table B.1 (commonly mapped to nothing) → empty.
+//   3. NFKC normalization.
+// We skip the prohibition (RFC 4013 §2.3) and bidi (RFC 3454 §6) checks.
+// libpq is forgiving on those paths and Postgres's own SASLprep matches that
+// leniency for legacy roles, so omitting the rejection logic keeps existing
+// roles working without adding complexity.
+function saslprep(password) {
+  // RFC 3454 Table C.1.2 — non-ASCII space characters, mapped to U+0020.
+  const nonAsciiSpace = /[\u00A0\u1680\u2000-\u200B\u202F\u205F\u3000]/g
+  // RFC 3454 Table B.1 — "commonly mapped to nothing". The set intentionally
+  // contains zero-width joiners and variation selectors — the very characters
+  // ESLint's no-misleading-character-class warns about — because they combine
+  // with their neighbors and the RFC strips them for that reason.
+  // eslint-disable-next-line no-misleading-character-class
+  const mappedToNothing = /[\u00AD\u034F\u1806\u180B\u180C\u180D\u200C\u200D\u2060\uFE00-\uFE0F\uFEFF]/g
+  return password.replace(nonAsciiSpace, ' ').replace(mappedToNothing, '').normalize('NFKC')
+}
+
 function startSession(mechanisms, stream) {
   const candidates = ['SCRAM-SHA-256']
   if (stream) candidates.unshift('SCRAM-SHA-256-PLUS') // higher-priority, so placed first
@@ -70,7 +98,7 @@ async function continueSession(session, password, serverData, stream) {
   const authMessage = clientFirstMessageBare + ',' + serverFirstMessage + ',' + clientFinalMessageWithoutProof
 
   const saltBytes = Buffer.from(sv.salt, 'base64')
-  const saltedPassword = await crypto.deriveKey(password, saltBytes, sv.iteration)
+  const saltedPassword = await crypto.deriveKey(saslprep(password), saltBytes, sv.iteration)
   const clientKey = await crypto.hmacSha256(saltedPassword, 'Client Key')
   const storedKey = await crypto.sha256(clientKey)
   const clientSignature = await crypto.hmacSha256(storedKey, authMessage)

--- a/packages/pg/test/integration/client/promise-api-tests.js
+++ b/packages/pg/test/integration/client/promise-api-tests.js
@@ -13,13 +13,6 @@ suite.test('valid connection completes promise', () => {
   })
 })
 
-suite.test('valid connection completes promise', () => {
-  const client = new pg.Client()
-  return client.connect().then(() => {
-    return client.end().then(() => {})
-  })
-})
-
 suite.test('valid connection returns the client in a promise', () => {
   const client = new pg.Client()
   return client.connect().then((clientInside) => {
@@ -28,25 +21,7 @@ suite.test('valid connection returns the client in a promise', () => {
   })
 })
 
-suite.test('invalid connection rejects promise', (done) => {
+suite.test('invalid connection rejects promise', async () => {
   const client = new pg.Client({ host: 'alksdjflaskdfj', port: 1234 })
-  return client.connect().catch((e) => {
-    assert(e instanceof Error)
-    done()
-  })
-})
-
-suite.test('connected client does not reject promise after connection', (done) => {
-  const client = new pg.Client()
-  return client.connect().then(() => {
-    setTimeout(() => {
-      client.on('error', (e) => {
-        assert(e instanceof Error)
-        client.end()
-        done()
-      })
-      // manually kill the connection
-      client.emit('error', new Error('something bad happened...but not really'))
-    }, 50)
-  })
+  await assert.rejects(client.connect(), Error)
 })

--- a/packages/pg/test/integration/client/sasl-scram-tests.js
+++ b/packages/pg/test/integration/client/sasl-scram-tests.js
@@ -108,3 +108,82 @@ suite.test('sasl/scram fails when password is empty', async () => {
   )
   assert.ok(usingSasl, 'Should be using SASL for authentication')
 })
+
+/**
+ * SASLprep regression coverage. RFC 5802 / RFC 4013 require the SCRAM client
+ * to normalize the password (B.1 mapping → NFKC → prohibition + bidi check)
+ * before feeding it into PBKDF2. PostgreSQL's server applies the same
+ * SASLprep when computing the verifier, so any password whose NFKC form
+ * differs from the raw form would otherwise authenticate against psql/libpq
+ * but fail against pg with `28P01`.
+ *
+ * To exercise these tests, provision a role whose password contains an
+ * NFKC-asymmetric character. For example, in psql:
+ *
+ *     SET password_encryption = 'scram-sha-256';
+ *     CREATE ROLE scram_unicode_test LOGIN PASSWORD U&'IX-\2168';
+ *
+ * `\2168` is ROMAN NUMERAL IX; the server SASLprep-normalizes this to
+ * `IX-IX` when computing the verifier. Then export:
+ *
+ *     SCRAM_TEST_PGUSER_UNICODE=scram_unicode_test
+ *     SCRAM_TEST_PGPASSWORD_UNICODE='IX-\u2168'   (i.e. the raw form)
+ *
+ * If either env var is unset the suite is skipped, matching the convention
+ * of the ASCII SCRAM block above.
+ */
+const unicodeConfig = {
+  user: process.env.SCRAM_TEST_PGUSER_UNICODE,
+  password: process.env.SCRAM_TEST_PGPASSWORD_UNICODE,
+  host: process.env.SCRAM_TEST_PGHOST,
+  port: process.env.SCRAM_TEST_PGPORT,
+  database: process.env.SCRAM_TEST_PGDATABASE,
+}
+
+if (!unicodeConfig.user || !unicodeConfig.password) {
+  suite.test('skipping SCRAM unicode tests (missing env)', () => {})
+} else {
+  suite.test('sasl/scram authenticates a password requiring SASLprep (raw form)', async () => {
+    const client = new pg.Client(unicodeConfig)
+    let usingSasl = false
+    client.connection.once('authenticationSASL', () => {
+      usingSasl = true
+    })
+    await client.connect()
+    assert.ok(usingSasl, 'Should be using SASL for authentication')
+    await client.end()
+  })
+
+  suite.test('sasl/scram authenticates the NFKC-equivalent ASCII form of the same password', async () => {
+    // The unicode password contains a codepoint that NFKC-decomposes to ASCII
+    // (e.g. U+2168 → "IX"). The server stored the verifier from the
+    // SASLprep'd ASCII form, so feeding the client the ASCII form directly
+    // must also authenticate. This proves that the prep step is symmetric:
+    // any NFKC-equivalent representation reaches the same PBKDF2 input.
+    const client = new pg.Client({
+      ...unicodeConfig,
+      password: unicodeConfig.password.normalize('NFKC'),
+    })
+    await client.connect()
+    await client.end()
+  })
+
+  suite.test('sasl/scram fails when unicode password is wrong', async () => {
+    const client = new pg.Client({
+      ...unicodeConfig,
+      password: unicodeConfig.password + 'append-something-to-make-it-bad',
+    })
+    let usingSasl = false
+    client.connection.once('authenticationSASL', () => {
+      usingSasl = true
+    })
+    await assert.rejects(
+      () => client.connect(),
+      {
+        code: '28P01',
+      },
+      'Error code should be for a password error'
+    )
+    assert.ok(usingSasl, 'Should be using SASL for authentication')
+  })
+}

--- a/packages/pg/test/integration/gh-issues/3174-tests.js
+++ b/packages/pg/test/integration/gh-issues/3174-tests.js
@@ -104,7 +104,9 @@ const testErrorBuffer = (bufferName, errorBuffer) => {
     if (!cli.native) {
       assert(errorHit)
       // further queries on the client should fail since its in an invalid state
-      await assert.rejects(() => client.query('SELECTR NOW()'), 'Further queries on the client should reject')
+      await assert.rejects(client.query('SELECT NOW()'), {
+        message: 'Client has encountered a connection error and is not queryable',
+      })
     }
 
     await closeServer()
@@ -129,7 +131,9 @@ const testErrorBuffer = (bufferName, errorBuffer) => {
     if (!cli.native) {
       assert(errorHit)
       // further queries on the client should fail since its in an invalid state
-      await assert.rejects(() => client.query('SELECTR NOW()'), 'Further queries on the client should reject')
+      await assert.rejects(client.query('SELECT NOW()'), {
+        message: 'Client has encountered a connection error and is not queryable',
+      })
     }
 
     await client.end()

--- a/packages/pg/test/unit/client/sasl-scram-tests.js
+++ b/packages/pg/test/unit/client/sasl-scram-tests.js
@@ -187,6 +187,64 @@ suite.test('sasl/scram', function () {
       assert.equal(session.response, 'c=eSws,r=ab,p=YVTEOwOD7khu/NulscjFegHrZoTXJBFI/7L61AN9khc=')
     })
 
+    suite.test('SASLprep maps non-ASCII space characters (RFC 3454 C.1.2) to U+0020 SPACE', async function () {
+      // SASLprep probably misuses the C.1.2 table; U+200B, in particular, is listed in both the C.1.2 and B.1 tables. We treat it as a space for compatibility with PostgreSQL.
+      const sessionPrepped = { message: 'SASLInitialResponse', clientNonce: 'a' }
+      const sessionRef = { message: 'SASLInitialResponse', clientNonce: 'a' }
+
+      await sasl.continueSession(sessionPrepped, '\u200bfoo\xa0bar', 'r=ab,s=abcd,i=1')
+      await sasl.continueSession(sessionRef, ' foo bar', 'r=ab,s=abcd,i=1')
+
+      assert.equal(sessionPrepped.serverSignature, sessionRef.serverSignature)
+      assert.equal(sessionPrepped.response, sessionRef.response)
+    })
+
+    suite.test('SASLprep maps mapped-to-nothing characters before PBKDF2 (RFC 3454 B.1)', async function () {
+      // Soft hyphen U+00AD is mapped to nothing by SASLprep, so 'I\u00ADX'
+      // must produce identical SCRAM output to 'IX'. This proves the prep
+      // step is engaged on the SCRAM derivation path. Without the fix the
+      // two would diverge and this assertion would fail.
+      const sessionPrepped = { message: 'SASLInitialResponse', clientNonce: 'a' }
+      const sessionRef = { message: 'SASLInitialResponse', clientNonce: 'a' }
+
+      await sasl.continueSession(sessionPrepped, 'I\u00ADX', 'r=ab,s=abcd,i=1')
+      await sasl.continueSession(sessionRef, 'IX', 'r=ab,s=abcd,i=1')
+
+      assert.equal(sessionPrepped.serverSignature, sessionRef.serverSignature)
+      assert.equal(sessionPrepped.response, sessionRef.response)
+    })
+
+    suite.test('SASLprep NFKC-normalizes passwords before PBKDF2 (RFC 4013 §2.2)', async function () {
+      // ROMAN NUMERAL IX (U+2168) NFKC-decomposes to the ASCII letters 'IX'.
+      // PostgreSQL's server applies SASLprep when computing the verifier, so
+      // a role created with U+2168 is stored as if it were 'IX'. The client
+      // must do the same.
+      const sessionPrepped = { message: 'SASLInitialResponse', clientNonce: 'a' }
+      const sessionRef = { message: 'SASLInitialResponse', clientNonce: 'a' }
+
+      await sasl.continueSession(sessionPrepped, '\u2168', 'r=ab,s=abcd,i=1')
+      await sasl.continueSession(sessionRef, 'IX', 'r=ab,s=abcd,i=1')
+
+      assert.equal(sessionPrepped.serverSignature, sessionRef.serverSignature)
+      assert.equal(sessionPrepped.response, sessionRef.response)
+    })
+
+    suite.test('passes ASCII control characters through normalization unchanged', async function () {
+      // BEL (U+0007) is an ASCII control character. The minimal SASLprep
+      // implementation (B.1 mapping → C.1.2 mapping → NFKC) is the identity
+      // on ASCII control codes, so the bytes fed to PBKDF2 are exactly the
+      // raw password. We snapshot the resulting SCRAM output as a regression
+      // guard: if anyone ever swaps the order of operations, removes the
+      // NFKC step, or accidentally strips ASCII bytes, this assertion trips.
+      const session = { message: 'SASLInitialResponse', clientNonce: 'a' }
+
+      await sasl.continueSession(session, '\u0007abc', 'r=ab,s=abcd,i=1')
+
+      assert.equal(session.message, 'SASLResponse')
+      assert.equal(session.serverSignature, 'ytJN8GA+9TeZpeS28ix+u0cwaIB7iFlWgpAsmy+MmP0=')
+      assert.equal(session.response, 'c=biws,r=ab,p=04HAPnY4K2UhwiD2RJtFw9sU81SLcas8B1Uqdqv8SeQ=')
+    })
+
     suite.test('sets expected session data (SCRAM-SHA-256-PLUS)', async function () {
       const session = {
         message: 'SASLInitialResponse',

--- a/packages/pg/test/unit/client/sasl-scram-tests.js
+++ b/packages/pg/test/unit/client/sasl-scram-tests.js
@@ -58,64 +58,53 @@ suite.test('sasl/scram', function () {
   })
 
   suite.test('continueSession', function () {
-    suite.test('fails when last session message was not SASLInitialResponse', async function () {
-      assert.rejects(
-        function () {
-          return sasl.continueSession({}, '', '')
-        },
-        {
-          message: 'SASL: Last message was not SASLInitialResponse',
-        }
-      )
+    suite.test('fails when last session message was not SASLInitialResponse', async () => {
+      await assert.rejects(sasl.continueSession({}, '', ''), {
+        message: 'SASL: Last message was not SASLInitialResponse',
+      })
     })
 
-    suite.test('fails when nonce is missing in server message', function () {
-      assert.rejects(
-        function () {
-          return sasl.continueSession(
-            {
-              message: 'SASLInitialResponse',
-            },
-            'bad-password',
-            's=1,i=1'
-          )
-        },
+    suite.test('fails when nonce is missing in server message', async () => {
+      await assert.rejects(
+        sasl.continueSession(
+          {
+            message: 'SASLInitialResponse',
+          },
+          'bad-password',
+          's=1,i=1'
+        ),
         {
           message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: nonce missing',
         }
       )
     })
 
-    suite.test('fails when salt is missing in server message', function () {
-      assert.rejects(
-        function () {
-          return sasl.continueSession(
-            {
-              message: 'SASLInitialResponse',
-            },
-            'bad-password',
-            'r=1,i=1'
-          )
-        },
+    suite.test('fails when salt is missing in server message', async () => {
+      await assert.rejects(
+        sasl.continueSession(
+          {
+            message: 'SASLInitialResponse',
+          },
+          'bad-password',
+          'r=1,i=1'
+        ),
         {
           message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: salt missing',
         }
       )
     })
 
-    suite.test('fails when client password is not a string', function () {
+    suite.test('fails when client password is not a string', async () => {
       for (const badPasswordValue of [null, undefined, 123, new Date(), {}]) {
-        assert.rejects(
-          function () {
-            return sasl.continueSession(
-              {
-                message: 'SASLInitialResponse',
-                clientNonce: 'a',
-              },
-              badPasswordValue,
-              'r=1,i=1'
-            )
-          },
+        await assert.rejects(
+          sasl.continueSession(
+            {
+              message: 'SASLInitialResponse',
+              clientNonce: 'a',
+            },
+            badPasswordValue,
+            'r=1,i=1'
+          ),
           {
             message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string',
           }
@@ -123,53 +112,47 @@ suite.test('sasl/scram', function () {
       }
     })
 
-    suite.test('fails when client password is an empty string', function () {
-      assert.rejects(
-        function () {
-          return sasl.continueSession(
-            {
-              message: 'SASLInitialResponse',
-              clientNonce: 'a',
-            },
-            '',
-            'r=1,i=1'
-          )
-        },
+    suite.test('fails when client password is an empty string', async () => {
+      await assert.rejects(
+        sasl.continueSession(
+          {
+            message: 'SASLInitialResponse',
+            clientNonce: 'a',
+          },
+          '',
+          'r=1,i=1'
+        ),
         {
           message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a non-empty string',
         }
       )
     })
 
-    suite.test('fails when iteration is missing in server message', function () {
-      assert.rejects(
-        function () {
-          return sasl.continueSession(
-            {
-              message: 'SASLInitialResponse',
-            },
-            'bad-password',
-            'r=1,s=abcd'
-          )
-        },
+    suite.test('fails when iteration is missing in server message', async () => {
+      await assert.rejects(
+        sasl.continueSession(
+          {
+            message: 'SASLInitialResponse',
+          },
+          'bad-password',
+          'r=1,s=abcd'
+        ),
         {
           message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: iteration missing',
         }
       )
     })
 
-    suite.test('fails when server nonce does not start with client nonce', function () {
-      assert.rejects(
-        function () {
-          return sasl.continueSession(
-            {
-              message: 'SASLInitialResponse',
-              clientNonce: '2',
-            },
-            'bad-password',
-            'r=1,s=abcd,i=1'
-          )
-        },
+    suite.test('fails when server nonce does not start with client nonce', async () => {
+      await assert.rejects(
+        sasl.continueSession(
+          {
+            message: 'SASLInitialResponse',
+            clientNonce: '2',
+          },
+          'bad-password',
+          'r=1,s=abcd,i=1'
+        ),
         {
           message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: server nonce does not start with client nonce',
         }

--- a/packages/pg/test/unit/client/simple-query-tests.js
+++ b/packages/pg/test/unit/client/simple-query-tests.js
@@ -118,39 +118,36 @@ test('executing query', function () {
     const client = helper.client()
 
     test('throws an error when config is null', function () {
-      try {
-        client.query(null, undefined)
-      } catch (error) {
-        assert.equal(
-          error.message,
-          'Client was passed a null or undefined query',
-          'Should have thrown an Error for null queries'
-        )
-      }
+      assert.throws(
+        () => {
+          client.query(null, undefined)
+        },
+        {
+          message: 'Client was passed a null or undefined query',
+        }
+      )
     })
 
     test('throws an error when config is undefined', function () {
-      try {
-        client.query()
-      } catch (error) {
-        assert.equal(
-          error.message,
-          'Client was passed a null or undefined query',
-          'Should have thrown an Error for null queries'
-        )
-      }
+      assert.throws(
+        () => {
+          client.query()
+        },
+        {
+          message: 'Client was passed a null or undefined query',
+        }
+      )
     })
 
     test('throws an error when callback is not a function', function () {
-      try {
-        client.query('SELECT $1', [1], 'notafunction')
-      } catch (error) {
-        assert.equal(
-          error.message,
-          'callback is not a function',
-          'Should have thrown an Error for non function callback'
-        )
-      }
+      assert.throws(
+        () => {
+          client.query('SELECT $1', [1], 'notafunction')
+        },
+        {
+          message: 'callback is not a function',
+        }
+      )
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5907,13 +5907,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libpq@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/libpq/-/libpq-1.10.0.tgz#238d01d416abca8768aab09bc82d81af9c7ffa23"
-  integrity sha512-PHY+JGD3+9X5b2emXLh+WJEnz1jhczO1xs25ZH0xbMWvQi+Hd9X/mTZOrGA99Rcw/DvNjsBRlegroqigpNfaJA==
+libpq@^1.8.15:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/libpq/-/libpq-1.11.0.tgz#1baf0920eb51ebe1399de942414e012142dcead8"
+  integrity sha512-mHoPlvMwYDMJV36bS2w3eSdFD4eDSm7P9FsvruUldQxzE23/W6qitT9VU/yD1+g2vpgpDktnk2iEYJyhy1RR5g==
   dependencies:
     bindings "1.5.0"
-    nan "~2.23.1"
+    nan "~2.26.2"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -6627,15 +6627,10 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@~2.22.2:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.2.tgz#6b504fd029fb8f38c0990e52ad5c26772fdacfbb"
-  integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
-
-nan@~2.23.1:
-  version "2.23.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.1.tgz#6f86a31dd87e3d1eb77512bf4b9e14c8aded3975"
-  integrity sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==
+nan@~2.26.2:
+  version "2.26.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.26.2.tgz#2e5e25764224c737b9897790b57c3294d4dcee9c"
+  integrity sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==
 
 nanoid@^3.3.11:
   version "3.3.11"


### PR DESCRIPTION
## What

Pulls in 4 upstream commits since #31. Bumps `@supabase/pg` → **8.21.1** (patch — sole runtime change is the SASLprep security fix). `@supabase/pg-protocol` is unchanged (no source under `packages/pg-protocol/` since #31), stays at `1.13.1` and its deploy workflow won't trigger on this merge per its `paths` filter.

## Why

- **`0ac3edde` fix: apply SASLprep (RFC 4013) to passwords before SCRAM-SHA-256 PBKDF2 (brianc#3669)** — security/correctness fix in `packages/pg/lib/crypto/sasl.js`. Adds an inline `saslprep()` helper (RFC 3454 Tables C.1.2 + B.1 mapping followed by NFKC normalization) and calls it in `continueSession()` before `crypto.deriveKey`, so passwords whose NFKC form differs from the raw form authenticate correctly against PostgreSQL (which applies SASLprep server-side, matching `libpq`/`psql` behaviour). Without it, affected accounts get `28P01` from any consumer using `@supabase/pg` while `psql`/`libpq` accept the same credentials. **This supersedes the manual port we'd staged in #32/#33** — closing those in favour of pulling the upstream version verbatim.
- **`63c921bb` ci: Node 26 followup (brianc#3670)** — touches only upstream's `ci.yml` (we don't run that workflow).
- **`be880d45` Assorted test fixes and cleanup (brianc#3672)** — test-only reshuffles in `packages/pg/test/`.
- **`c73a6457` test: Ensure failure to throw at all doesn't pass (brianc#3671)** — `sasl-scram-tests` harness fix that catches a previously silent assertion-skipping bug.

## How (merge mechanics)

Same single conflict as #31: modify-vs-delete on `.github/workflows/ci.yml` (upstream modified, we deleted). Kept it deleted. Every patched file we own (`connection.js`, `parser.ts`, `native/client.js`, `native/query.js`, `defaults.js`, `client.js`, all `package.json`s, README) was untouched by upstream, so the merge auto-resolved with no manual intervention beyond removing `ci.yml`.

Also took upstream's `packages/pg-native/package.json` `libpq` pin loosening (`^1.11.0` → `^1.8.15`) — the constraint widening helps `libpq` native builds on older toolchains and is preserved by the auto-merge against our supabase URL changes.

## Hygiene

Adds `*.tsbuildinfo` to `.gitignore` — TypeScript incremental build artifacts had been silently leaking into `git status` from local validation runs of `pg-protocol`. One-line gitignore addition; the two leaked files were unstaged and removed before commit.

## Validation

- `node --check` passes on `lib/crypto/sasl.js` and every modified test file.
- `npm publish --dry-run` for `@supabase/pg@8.21.1` produces the expected `supabase-pg-8.21.1.tgz` tarball.
- Full `pg` integration tests will run post-publish via `postgres-meta` CI, same pattern as #29 / #31.

## After merge

Only `deploy-pg.yml` will trigger (`packages/pg/**` changed). `deploy-pg-protocol.yml` will skip per its `paths` filter (`packages/pg-protocol/**` unchanged). Expected outcome: `@supabase/pg@8.21.1` published to npm.